### PR TITLE
Update action name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ To get the latest stable version of `protoc` just add this step:
 
 ```yaml
 - name: Install Protoc
-  uses: Arduino/actions/setup-protoc@master
+  uses: arduino/setup-protoc@master
 ```
 
 If you want to pin a major or minor version you can use the `.x` wildcard:
 
 ```yaml
 - name: Install Protoc
-  uses: Arduino/actions/setup-protoc@master
+  uses: arduino/setup-protoc@master
   with:
     version: '3.x'
 ```
@@ -24,7 +24,7 @@ You can also require to include releases marked as `pre-release` in Github using
 
 ```yaml
 - name: Install Protoc
-  uses: Arduino/actions/setup-protoc@master
+  uses: arduino/setup-protoc@master
   with:
     version: '3.x'
     include-pre-releases: true
@@ -34,7 +34,7 @@ To pin the exact version:
 
 ```yaml
 - name: Install Protoc
-  uses: Arduino/actions/setup-protoc@master
+  uses: arduino/setup-protoc@master
   with:
     version: '3.9.1'
 ```


### PR DESCRIPTION
The documentation was still demonstrating the use of the deprecated action `arduino/actions/setup-protoc`.

Fixes https://github.com/arduino/setup-protoc/issues/4