### PR TITLE
Support linux arm64 architecture

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -126,7 +126,7 @@ function getFileName(version: string): string {
     return util.format("protoc-%s-win%s.zip", version, arch);
   }
 
-  const arch: string = (function (): string {
+  const arch: string = (function(): string {
     switch (osArch) {
       case "x64":
         return "x86_64";

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -126,7 +126,16 @@ function getFileName(version: string): string {
     return util.format("protoc-%s-win%s.zip", version, arch);
   }
 
-  const arch: string = osArch == "x64" ? "x86_64" : "x86_32";
+  const arch: string = (function (): string {
+    switch (osArch) {
+      case "x64":
+        return "x86_64";
+      case "arm64":
+        return "aarch_64";
+      default:
+        return "x86_32";
+    }
+  })();
 
   if (osPlat == "darwin") {
     return util.format("protoc-%s-osx-%s.zip", version, arch);


### PR DESCRIPTION
Fixes #25 

Downloads `aarch_64` release for `arm64` architecture.