### PR TITLE
Add CI workflow to check for unapproved npm dependency licenses

### DIFF
--- a/.github/workflows/check-npm-dependencies-task.yml
+++ b/.github/workflows/check-npm-dependencies-task.yml
@@ -1,0 +1,140 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-npm-dependencies-task.md
+name: Check npm Dependencies
+
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 10.x
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - ".github/workflows/check-npm-dependencies-task.ya?ml"
+      - ".licenses/**"
+      - ".licensed.json"
+      - ".licensed.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.gitmodules"
+      - "**/package.json"
+      - "**/package-lock.json"
+  pull_request:
+    paths:
+      - ".github/workflows/check-npm-dependencies-task.ya?ml"
+      - ".licenses/**"
+      - ".licensed.json"
+      - ".licensed.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.gitmodules"
+      - "**/package.json"
+      - "**/package-lock.json"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
+  check-cache:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install licensed
+        uses: jonabc/setup-licensed@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Update dependencies license metadata cache
+        run: task --silent general:cache-dep-licenses
+
+      - name: Check for outdated cache
+        id: diff
+        run: |
+          git add .
+          if ! git diff --cached --color --exit-code; then
+            echo
+            echo "::error::Dependency license metadata out of sync. See: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md#metadata-cache"
+            exit 1
+          fi
+
+      # Some might find it convenient to have CI generate the cache rather than setting up for it locally
+      - name: Upload cache to workflow artifact
+        if: failure() && steps.diff.outcome == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: dep-licenses-cache
+          path: .licenses/
+
+  check-deps:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install licensed
+        uses: jonabc/setup-licensed@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check for dependencies with unapproved licenses
+        run: task --silent general:check-dep-licenses

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,0 +1,88 @@
+# See: https://github.com/github/licensed/blob/master/docs/configuration.md
+
+sources:
+  npm: true
+
+shared_cache: true
+cache_path: .licenses/
+
+apps:
+  - source_path: ./
+
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
+allowed:
+  # The following are based on: https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses
+  - gpl-1.0-or-later
+  - gpl-1.0+ # Deprecated ID for `gpl-1.0-or-later`
+  - gpl-2.0-or-later
+  - gpl-2.0+ # Deprecated ID for `gpl-2.0-or-later`
+  - gpl-3.0-only
+  - gpl-3.0 # Deprecated ID for `gpl-3.0-only`
+  - gpl-3.0-or-later
+  - gpl-3.0+ # Deprecated ID for `gpl-3.0-or-later`
+  - lgpl-2.0-or-later
+  - lgpl-2.0+ # Deprecated ID for `lgpl-2.0-or-later`
+  - lgpl-2.1-only
+  - lgpl-2.1 # Deprecated ID for `lgpl-2.1-only`
+  - lgpl-2.1-or-later
+  - lgpl-2.1+ # Deprecated ID for `lgpl-2.1-or-later`
+  - lgpl-3.0-only
+  - lgpl-3.0 # Deprecated ID for `lgpl-3.0-only`
+  - lgpl-3.0-or-later
+  - lgpl-3.0+ # Deprecated ID for `lgpl-3.0-or-later`
+  - fsfap
+  - apache-2.0
+  - artistic-2.0
+  - clartistic
+  - sleepycat
+  - bsl-1.0
+  - bsd-3-clause
+  - cecill-2.0
+  - bsd-3-clause-clear
+  # "Cryptix General License" - no SPDX ID (https://github.com/spdx/license-list-XML/issues/456)
+  - ecos-2.0
+  - ecl-2.0
+  - efl-2.0
+  - eudatagrid
+  - mit
+  - bsd-2-clause # Subsumed by `bsd-2-clause-views`
+  - bsd-2-clause-netbsd # Deprecated ID for `bsd-2-clause`
+  - bsd-2-clause-views # This is the version linked from https://www.gnu.org/licenses/license-list.html#FreeBSD
+  - bsd-2-clause-freebsd # Deprecated ID for `bsd-2-clause-views`
+  - ftl
+  - hpnd
+  - imatix
+  - imlib2
+  - ijg
+  # "Informal license" - this is a general class of license
+  - intel
+  - isc
+  - mpl-2.0
+  - ncsa
+  # "License of Netscape JavaScript" - no SPDX ID
+  - oldap-2.7
+  # "License of Perl 5 and below" - possibly `Artistic-1.0-Perl` ?
+  - cc0-1.0
+  - cc-pddc
+  - psf-2.0
+  - ruby
+  - sgi-b-2.0
+  - smlnj
+  - standardml-nj # Deprecated ID for `smlnj`
+  - unicode-dfs-2015
+  - upl-1.0
+  - unlicense
+  - vim
+  - w3c
+  - wtfpl
+  - lgpl-2.0-or-later with wxwindows-exception-3.1
+  - wxwindows # Deprecated ID for `lgpl-2.0-or-later with wxwindows-exception-3.1`
+  - x11
+  - xfree86-1.1
+  - zlib
+  - zpl-2.0
+  - zpl-2.1
+  # The following are based on individual license text
+  - eupl-1.2
+  - liliq-r-1.1
+  - liliq-rplus-1.1

--- a/.licenses/npm/@actions/core.dep.yml
+++ b/.licenses/npm/@actions/core.dep.yml
@@ -1,0 +1,20 @@
+---
+name: "@actions/core"
+version: 1.2.6
+type: npm
+summary: Actions core lib
+homepage: https://github.com/actions/toolkit/tree/main/packages/core
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |-
+    The MIT License (MIT)
+
+    Copyright 2019 GitHub
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/npm/@actions/exec.dep.yml
+++ b/.licenses/npm/@actions/exec.dep.yml
@@ -1,0 +1,18 @@
+---
+name: "@actions/exec"
+version: 1.0.0
+type: npm
+summary: Actions exec lib
+homepage: https://github.com/actions/toolkit/tree/master/packages/exec
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |-
+    Copyright 2019 GitHub
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/npm/@actions/io.dep.yml
+++ b/.licenses/npm/@actions/io.dep.yml
@@ -1,0 +1,18 @@
+---
+name: "@actions/io"
+version: 1.0.0
+type: npm
+summary: Actions io lib
+homepage: https://github.com/actions/toolkit/tree/master/packages/io
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |-
+    Copyright 2019 GitHub
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/npm/@actions/tool-cache.dep.yml
+++ b/.licenses/npm/@actions/tool-cache.dep.yml
@@ -1,0 +1,30 @@
+---
+name: "@actions/tool-cache"
+version: 1.1.0
+type: npm
+summary: Actions tool-cache lib
+homepage: https://github.com/actions/toolkit/tree/master/packages/exec
+license: mit
+licenses:
+- sources: Auto-generated MIT license text
+  text: |
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/npm/semver.dep.yml
+++ b/.licenses/npm/semver.dep.yml
@@ -1,0 +1,26 @@
+---
+name: semver
+version: 6.3.0
+type: npm
+summary: The semantic version parser used by npm.
+homepage: https://github.com/npm/node-semver#readme
+license: isc
+licenses:
+- sources: LICENSE
+  text: |
+    The ISC License
+
+    Copyright (c) Isaac Z. Schlueter and Contributors
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+    IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+notices: []

--- a/.licenses/npm/tunnel.dep.yml
+++ b/.licenses/npm/tunnel.dep.yml
@@ -1,0 +1,35 @@
+---
+name: tunnel
+version: 0.0.4
+type: npm
+summary: Node HTTP/HTTPS Agents for tunneling proxies
+homepage: https://github.com/koichik/node-tunnel/
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2012 Koichi Kobayashi
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: Licensed under the [MIT](https://github.com/koichik/node-tunnel/blob/master/LICENSE)
+    license.
+notices: []

--- a/.licenses/npm/typed-rest-client.dep.yml
+++ b/.licenses/npm/typed-rest-client.dep.yml
@@ -4,7 +4,7 @@ version: 1.5.0
 type: npm
 summary: Node Rest and Http Clients for use with TypeScript
 homepage: https://github.com/Microsoft/typed-rest-client#readme
-license: other
+license: mit
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/npm/typed-rest-client.dep.yml
+++ b/.licenses/npm/typed-rest-client.dep.yml
@@ -1,0 +1,32 @@
+---
+name: typed-rest-client
+version: 1.5.0
+type: npm
+summary: Node Rest and Http Clients for use with TypeScript
+homepage: https://github.com/Microsoft/typed-rest-client#readme
+license: other
+licenses:
+- sources: LICENSE
+  text: |
+    Typed Rest Client for Node.js
+
+    Copyright (c) Microsoft Corporation
+
+    All rights reserved.
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+    associated documentation files (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+    LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/npm/underscore.dep.yml
+++ b/.licenses/npm/underscore.dep.yml
@@ -1,0 +1,34 @@
+---
+name: underscore
+version: 1.8.3
+type: npm
+summary: JavaScript's functional programming helper library.
+homepage: http://underscorejs.org
+license: other
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative
+    Reporters & Editors
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following
+    conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/npm/underscore.dep.yml
+++ b/.licenses/npm/underscore.dep.yml
@@ -4,7 +4,7 @@ version: 1.8.3
 type: npm
 summary: JavaScript's functional programming helper library.
 homepage: http://underscorejs.org
-license: other
+license: mit
 licenses:
 - sources: LICENSE
   text: |

--- a/.licenses/npm/uuid.dep.yml
+++ b/.licenses/npm/uuid.dep.yml
@@ -1,0 +1,39 @@
+---
+name: uuid
+version: 3.3.2
+type: npm
+summary: RFC4122 (v1, v4, and v5) UUIDs
+homepage: https://github.com/kelektiv/node-uuid#readme
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices:
+- sources: AUTHORS
+  text: |-
+    Robert Kieffer <robert@broofa.com>
+    Christoph Tavan <dev@tavan.de>
+    AJ ONeal <coolaj86@gmail.com>
+    Vincent Voyer <vincent@zeroload.net>
+    Roman Shtylman <shtylman@gmail.com>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # setup-protoc
 
+[![Check npm Dependencies status](https://github.com/arduino/setup-protoc/actions/workflows/check-npm-dependencies-task.yml/badge.svg)](https://github.com/arduino/setup-protoc/actions/workflows/check-npm-dependencies-task.yml)
 ![test](https://github.com/arduino/setup-protoc/workflows/test/badge.svg)
 
 This action makes the `protoc` compiler available to Workflows.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,39 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
+  general:cache-dep-licenses:
+    desc: Cache dependency license metadata
+    cmds:
+      - |
+        if ! which licensed &>/dev/null; then
+          if [[ {{OS}} == "windows" ]]; then
+            echo "Licensed does not have Windows support."
+            echo "Please use Linux/macOS or download the dependencies cache from the GitHub Actions workflow artifact."
+          else
+            echo "licensed not found or not in PATH. Please install: https://github.com/github/licensed#as-an-executable"
+          fi
+          exit 1
+        fi
+      - licensed cache
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
+  general:check-dep-licenses:
+    desc: Check for unapproved dependency licenses
+    deps:
+      - task: general:cache-dep-licenses
+    cmds:
+      - licensed status
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-npm-dependencies-task/Taskfile.yml
+  general:install-deps:
+    desc: Install project dependencies
+    deps:
+      - task: npm:install-deps
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
+  npm:install-deps:
+    desc: Install dependencies managed by npm
+    cmds:
+      - npm install

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -20,3 +20,17 @@ git commit -m "Informative commit message"  # Commit. This will run Husky
 
 During the commit step, Husky will take care of formatting all files with [Prettier](https://github.com/prettier/prettier) as well as pruning out devDependencies using `npm prune --production`.
 It will also make sure these changes are appropriately included in your commit (no further work is needed)
+
+## Dependency license metadata
+
+Metadata about the license types of all dependencies is cached in the repository. To update this cache, run the following command from the repository root folder:
+
+```
+task general:cache-dep-licenses
+```
+
+The necessary **Licensed** tool can be installed by following [these instructions](https://github.com/github/licensed#as-an-executable).
+
+Unfortunately, **Licensed** does not have support for being used on the **Windows** operating system.
+
+An updated cache is also generated whenever the cache is found to be outdated by the by the "Check Go Dependencies" CI workflow and made available for download via the `dep-licenses-cache` [workflow artifact](https://docs.github.com/actions/managing-workflow-runs/downloading-workflow-artifacts).


### PR DESCRIPTION
A task and GitHub Actions workflow are provided here for checking the license types of [**npm**](https://www.npmjs.com/)-managed project dependencies.

On every push and pull request that affects relevant files, the CI workflow will use [**Licensed**](https://github.com/github/licensed) to check:

- If the dependency licenses cache is up to date
- If any of the project's dependencies have an unapproved license type.

Approval can be based on:

- [Allowed license type](https://github.com/github/licensed/blob/master/docs/configuration/allowed_licenses.md)
- [Individual dependency](https://github.com/github/licensed/blob/master/docs/configuration/reviewing_dependencies.md)

---

Related: https://github.com/arduino/setup-protoc/issues/34