### PR TITLE
Update URL of taskfile schema in check-taskfiles workflow

### DIFF
--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -48,10 +48,10 @@ jobs:
 
       - name: Download JSON schema for Taskfiles
         id: download-schema
-        uses: carlosperate/download-file-action@v1
+        uses: carlosperate/download-file-action@v2
         with:
-          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/taskfile.json
-          file-url: https://json.schemastore.org/taskfile.json
+          # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/taskfile.json
+          file-url: https://taskfile.dev/schema.json
           location: ${{ runner.temp }}/taskfile-schema
 
       - name: Install JSON schema validator


### PR DESCRIPTION
[check-taskfiles](https://github.com/arduino/setup-protoc/blob/master/.github/workflows/check-taskfiles.yml) is currently failing with this error:

```
schema /home/runner/work/_temp/taskfile-schema/taskfile.json is invalid
error: can't resolve reference https://taskfile.dev/schema.json from id #
```
The url from which the schema is downloaded was recently changed in the assets repo to solve this issue: https://github.com/arduino/tooling-project-assets/pull/286
Those changes are now being applied to this repository as well.