### PR TITLE
Add CI workflow to validate tsconfig files

### DIFF
--- a/.github/workflows/check-tsconfig-task.yml
+++ b/.github/workflows/check-tsconfig-task.yml
@@ -1,0 +1,54 @@
+name: Check TypeScript Configuration
+
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 16.x
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-tsconfig-task.ya?ml"
+      - "**/tsconfig*.json"
+      - "Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-tsconfig-task.ya?ml"
+      - "**/tsconfig*.json"
+      - "Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        file:
+          - ./tsconfig.json
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate ${{ matrix.file }}
+        env:
+          TSCONFIG_PATH: ${{ matrix.file }}
+        run: task --silent ts:validate

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Integration Tests status](https://github.com/arduino/setup-protoc/actions/workflows/test-integration.yml/badge.svg)](https://github.com/arduino/setup-protoc/actions/workflows/test-integration.yml)
 [![Check npm status](https://github.com/arduino/setup-protoc/actions/workflows/check-npm-task.yml/badge.svg)](https://github.com/arduino/setup-protoc/actions/workflows/check-npm-task.yml)
 [![Check TypeScript status](https://github.com/arduino/setup-protoc/actions/workflows/check-typescript-task.yml/badge.svg)](https://github.com/arduino/setup-protoc/actions/workflows/check-typescript-task.yml)
+[![Check tsconfig status](https://github.com/arduino/setup-protoc/actions/workflows/check-tsconfig-task.yml/badge.svg)](https://github.com/arduino/setup-protoc/actions/workflows/check-tsconfig-task.yml)
 
 This action makes the `protoc` compiler available to Workflows.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -194,6 +194,38 @@ tasks:
           -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
           -d "{{.PROJECT_FOLDER}}/{{.INSTANCE_PATH}}"
 
+  ts:validate:
+    desc: Validate TypeScript configuration file against its JSON schema
+    vars:
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/tsconfig.json
+      SCHEMA_URL: https://json.schemastore.org/tsconfig.json
+      SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="tsconfig-schema-XXXXXXXXXX.json"
+      INSTANCE_PATH: '{{default "./tsconfig.json" .TSCONFIG_PATH}}'
+      WORKING_FOLDER:
+        sh: task utility:mktemp-folder TEMPLATE="ts-validate-XXXXXXXXXX"
+      WORKING_INSTANCE_PATH:
+        sh: echo "{{.WORKING_FOLDER}}/$(basename "{{.INSTANCE_PATH}}")"
+    cmds:
+      - |
+        # TypeScript allows comments in tsconfig.json.
+        # ajv-cli did not support comments in JSON at the 3.x version in use (support was added in a later version).
+        npx strip-json-comments-cli \
+          --no-whitespace \
+          "{{.INSTANCE_PATH}}" \
+          > "{{.WORKING_INSTANCE_PATH}}"
+      - |
+        wget \
+          --quiet \
+          --output-document="{{.SCHEMA_PATH}}" \
+          {{.SCHEMA_URL}}
+      - |
+        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
+        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
+          --all-errors \
+          -s "{{.SCHEMA_PATH}}" \
+          -d "{{.WORKING_INSTANCE_PATH}}"
+
   # Make a temporary file named according to the passed TEMPLATE variable and print the path passed to stdout
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
   utility:mktemp-file:


### PR DESCRIPTION
On every push or pull request that affects the repository's tsconfig files, and periodically, validate them against the JSON schema.