### PR TITLE
Add CI workflow to run integration tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,0 +1,89 @@
+name: Integration Tests
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/test-integration.ya?ml"
+      - "lib/**"
+      - "action.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/test-integration.ya?ml"
+      - "lib/**"
+      - "action.yml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by external changes.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  defaults:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run action with defaults
+        uses: ./ # Use the action from the local path.
+
+      - name: Run protoc
+        # Verify that protoc was installed
+        run: protoc --version
+
+  version:
+    name: version (${{ matrix.version.input }}, ${{ matrix.runs-on }})
+    runs-on: ${{ matrix.runs-on }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        version:
+          - input: 3.x
+            expected: "libprotoc 3.20.3"
+          - input: 3.17.x
+            expected: "libprotoc 3.17.3"
+          - input: 3.17.2
+            expected: "libprotoc 3.17.2"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run action, using protoc minor version wildcard
+        uses: ./
+        with:
+          version: '${{ matrix.version.input }}'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check protoc version
+        shell: bash
+        run: |
+          [[ "$(protoc --version)" == "${{ matrix.version.expected }}" ]]
+
+  invalid-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run action, using invalid version
+        id: setup-protoc
+        continue-on-error: true
+        uses: ./
+        with:
+          version: 2.42.x
+
+      - name: Fail the job if the action run succeeded
+        if: steps.setup-task.outcome == 'success'
+        run: |
+          echo "::error::The action run was expected to fail, but passed!"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Check Markdown status](https://github.com/arduino/setup-protoc/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/setup-protoc/actions/workflows/check-markdown-task.yml)
 [![Check License status](https://github.com/arduino/setup-protoc/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/setup-protoc/actions/workflows/check-license.yml)
 [![Check Taskfiles status](https://github.com/arduino/setup-protoc/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/setup-protoc/actions/workflows/check-taskfiles.yml)
+[![Integration Tests status](https://github.com/arduino/setup-protoc/actions/workflows/test-integration.yml/badge.svg)](https://github.com/arduino/setup-protoc/actions/workflows/test-integration.yml)
 
 This action makes the `protoc` compiler available to Workflows.
 


### PR DESCRIPTION
On every push and pull request that affects relevant files, run the integration tests.

The test checks if `setup-protoc` works correctly when `version` has the `.x` wildcard. Right now, `3.x` downloads the latest protoc version, so the test must either be updated manually until `4.x` is released or removed. Unfortunately it's not possible to use `2.x` because [2.6.1](https://github.com/protocolbuffers/protobuf/releases/tag/v2.6.1) does not work on the github runners.