### PR TITLE
installer: fix semver comparison with new-style protobuf versions

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,11 +1,7 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -18,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -109,7 +109,7 @@ function getFileName(version) {
     const parsed = semver.parse(version);
     // We normalized versions like 21.10 into 21.10.0 earlier; to actually get
     // their file we have to de-normalize them back to 21.10.
-    if parsed.major > 3 {
+    if (parsed.major > 3) {
         version = `${parsed.major}.${parsed.minor}`;
         core.debug(`denormalized ${parsed.version} to ${version}`);
     }

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -106,6 +106,14 @@ function downloadRelease(version) {
     });
 }
 function getFileName(version) {
+    parsed = semver.parse(version);
+    // We normalized versions like 21.10 into 21.10.0 earlier; to actually get
+    // their file we have to de-normalize them back to 21.10.
+    if parsed.major > 3 {
+        version = `${parsed.major}.${parsed.minor}`;
+        core.debug(`denormalized ${parsed.version} to ${version}`);
+    }
+
     // to compose the file name, strip the leading `v` char
     if (version.startsWith("v")) {
         version = version.slice(1, version.length);
@@ -159,6 +167,7 @@ function normalizeTag(tag) {
     if (tag.split(".").length === 3) {
         return tag;
     } else if (tag.split(".").length === 2) {
+        core.debug(`normalizing release tag ${tag} to ${tag}.0`);
         return `${tag}.0`;
     }
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,20 +1,38 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getProtoc = void 0;
 // Load tempDirectory before it gets wiped by tool-cache
 let tempDirectory = process.env["RUNNER_TEMP"] || "";
 const os = __importStar(require("os"));
@@ -52,6 +70,9 @@ function getProtoc(version, includePreReleases, repoToken) {
             version = targetVersion;
         }
         process.stdout.write("Getting protoc version: " + version + os.EOL);
+        // "denormalize" the version; this denormalized form is used both
+        // for the cache and for `downloadRelease`.
+        version = denormalizeVersion(version);
         // look if the binary is cached
         let toolPath;
         toolPath = tc.find("protoc", version);
@@ -88,7 +109,6 @@ exports.getProtoc = getProtoc;
 function downloadRelease(version) {
     return __awaiter(this, void 0, void 0, function* () {
         // Download
-        version = denormalizeVersion(version);
         let fileName = getFileName(version);
         let downloadUrl = util.format("https://github.com/protocolbuffers/protobuf/releases/download/%s/%s", version, fileName);
         process.stdout.write("Downloading archive: " + downloadUrl + os.EOL);
@@ -97,7 +117,6 @@ function downloadRelease(version) {
             downloadPath = yield tc.downloadTool(downloadUrl);
         }
         catch (error) {
-            core.debug(error);
             throw `Failed to download version ${version}: ${error}`;
         }
         // Extract
@@ -108,6 +127,9 @@ function downloadRelease(version) {
 }
 function denormalizeVersion(version) {
     const parsed = semver.parse(version);
+    if (parsed === null) {
+        throw new Error(`unable to parse ${version} as SemVer`);
+    }
     // We normalized versions like 21.10 into 21.10.0 earlier; to actually get
     // their file we have to de-normalize them back to 21.10.
     if (parsed.major > 3) {
@@ -116,7 +138,6 @@ function denormalizeVersion(version) {
         version = `v${parsed.major}.${parsed.minor}`;
         core.debug(`denormalized ${parsed.version} to ${version}`);
     }
-
     return version;
 }
 function getFileName(version) {
@@ -172,11 +193,11 @@ function fetchVersions(includePreReleases, repoToken) {
 function normalizeTag(tag) {
     if (tag.split(".").length === 3) {
         return tag;
-    } else if (tag.split(".").length === 2) {
+    }
+    else if (tag.split(".").length === 2) {
         core.debug(`normalizing release tag ${tag} to ${tag}.0`);
         return `${tag}.0`;
     }
-
     throw new Error(`unexpected release tag format: ${tag}`);
 }
 // Compute an actual version starting from the `version` configuration param.

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -147,8 +147,22 @@ function fetchVersions(includePreReleases, repoToken) {
         return tags
             .filter(tag => tag.tag_name.match(/v\d+\.[\w\.]+/g))
             .filter(tag => includePrerelease(tag.prerelease, includePreReleases))
-            .map(tag => tag.tag_name.replace("v", ""));
+            .map(tag => tag.tag_name.replace("v", ""))
+            .map(normalizeTag);
     });
+}
+// Starting after v3.20.3, the tagging scheme switched to vX.Y, where
+// X is the former minor and Y is the former patch.
+// This "normalizes" the new tagging scheme into a semver-style vX.Y.Z,
+// where Z is always 0.
+function normalizeTag(tag) {
+    if (tag.split(",").length - 1 === 3) {
+        return tag;
+    } else if (tag.split(",").length - 1 === 2) {
+        return `${tag}.0`;
+    }
+
+    throw new Error(`unexpected release tag format: ${tag}`);
 }
 // Compute an actual version starting from the `version` configuration param.
 function computeVersion(version, includePreReleases, repoToken) {

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -106,7 +106,7 @@ function downloadRelease(version) {
     });
 }
 function getFileName(version) {
-    parsed = semver.parse(version);
+    const parsed = semver.parse(version);
     // We normalized versions like 21.10 into 21.10.0 earlier; to actually get
     // their file we have to de-normalize them back to 21.10.
     if parsed.major > 3 {

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -156,9 +156,9 @@ function fetchVersions(includePreReleases, repoToken) {
 // This "normalizes" the new tagging scheme into a semver-style vX.Y.Z,
 // where Z is always 0.
 function normalizeTag(tag) {
-    if (tag.split(",").length - 1 === 3) {
+    if (tag.split(".").length === 3) {
         return tag;
-    } else if (tag.split(",").length - 1 === 2) {
+    } else if (tag.split(".").length === 2) {
         return `${tag}.0`;
     }
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -111,7 +111,9 @@ function denormalizeVersion(version) {
     // We normalized versions like 21.10 into 21.10.0 earlier; to actually get
     // their file we have to de-normalize them back to 21.10.
     if (parsed.major > 3) {
-        version = `${parsed.major}.${parsed.minor}`;
+        // We intentionally re-add the `v` prefix here, since the version
+        // coming in is from computeVersion, which also explicitly adds it.
+        version = `v${parsed.major}.${parsed.minor}`;
         core.debug(`denormalized ${parsed.version} to ${version}`);
     }
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -88,6 +88,7 @@ exports.getProtoc = getProtoc;
 function downloadRelease(version) {
     return __awaiter(this, void 0, void 0, function* () {
         // Download
+        version = denormalizeVersion(version);
         let fileName = getFileName(version);
         let downloadUrl = util.format("https://github.com/protocolbuffers/protobuf/releases/download/%s/%s", version, fileName);
         process.stdout.write("Downloading archive: " + downloadUrl + os.EOL);
@@ -105,7 +106,7 @@ function downloadRelease(version) {
         return yield tc.cacheDir(extPath, "protoc", version);
     });
 }
-function getFileName(version) {
+function denormalizeVersion(version) {
     const parsed = semver.parse(version);
     // We normalized versions like 21.10 into 21.10.0 earlier; to actually get
     // their file we have to de-normalize them back to 21.10.
@@ -114,6 +115,9 @@ function getFileName(version) {
         core.debug(`denormalized ${parsed.version} to ${version}`);
     }
 
+    return version;
+}
+function getFileName(version) {
     // to compose the file name, strip the leading `v` char
     if (version.startsWith("v")) {
         version = version.slice(1, version.length);

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,11 +1,7 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -18,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,18 +1,35 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
     return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -202,9 +202,10 @@ function normalizeTag(tag: string): string {
   } else if (tag.split(".").length === 2) {
     core.debug(`normalizing release tag ${tag} to ${tag}.0`);
     return `${tag}.0`;
+  } else {
+    core.debug(`unknown tag format: ${tag}; forwarding`);
+    return tag;
   }
-
-  throw new Error(`unexpected release tag format: ${tag}`);
 }
 
 // Compute an actual version starting from the `version` configuration param.

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -176,7 +176,7 @@ async function fetchVersions(
     let nextPage: IProtocRelease[] =
       (await rest.get<IProtocRelease[]>(
         "https://api.github.com/repos/protocolbuffers/protobuf/releases?page=" +
-        pageNum
+          pageNum
       )).result || [];
     if (nextPage.length > 0) {
       tags = tags.concat(nextPage);

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ async function run() {
     );
     let repoToken = core.getInput("repo-token");
     await installer.getProtoc(version, includePreReleases, repoToken);
-  } catch (error: any) {
+  } catch (error) {
     core.setFailed(error.message);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ async function run() {
     );
     let repoToken = core.getInput("repo-token");
     await installer.getProtoc(version, includePreReleases, repoToken);
-  } catch (error) {
+  } catch (error: any) {
     core.setFailed(error.message);
   }
 }


### PR DESCRIPTION
This should fix #33.

I'm not much of a JavaScript developer, so style feedback is greatly appreciated.

