### PR TITLE
chore: update @types/node from ^12.0.4 to ^18.11.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@actions/io": "^1.0.0",
         "@types/jest": "^24.0.13",
-        "@types/node": "^12.0.4",
+        "@types/node": "^18.11.17",
         "@types/semver": "^6.0.0",
         "ajv-cli": "^5.0.0",
         "ajv-formats": "^2.1.1",
@@ -1505,9 +1505,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "12.6.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
     },
     "node_modules/@types/responselike": {
@@ -11289,9 +11289,9 @@
       }
     },
     "@types/node": {
-      "version": "12.6.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
     },
     "@types/responselike": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@actions/io": "^1.0.0",
     "@types/jest": "^24.0.13",
-    "@types/node": "^12.0.4",
+    "@types/node": "^18.11.17",
     "@types/semver": "^6.0.0",
     "ajv-cli": "^5.0.0",
     "ajv-formats": "^2.1.1",


### PR DESCRIPTION
GitHub Actions are deprecating Node12, and any pipelines using this will get a warning. [Blog post here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). 

This PR updates `@types/node` to the latest version and to prevent `setup-protoc` from not working in the future. 