### PR TITLE
Expose `path` and `version` in `outputs`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,11 @@ inputs:
   repo-token:
     description: 'GitHub repo token to use to avoid rate limiter'
     default: ''
+outputs:
+  version:
+    description: 'Actual version of the protoc compiler environment that has been installed'
+  path:
+    description: 'Path to where the protoc compiler has been installed'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -85,6 +85,9 @@ function getProtoc(version, includePreReleases, repoToken) {
             toolPath = yield downloadRelease(version);
             process.stdout.write("Protoc cached under " + toolPath + os.EOL);
         }
+        // expose outputs
+        core.setOutput("path", toolPath);
+        core.setOutput("version", targetVersion);
         // add the bin folder to the PATH
         core.addPath(path.join(toolPath, "bin"));
     });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -63,6 +63,10 @@ export async function getProtoc(
     process.stdout.write("Protoc cached under " + toolPath + os.EOL);
   }
 
+  // expose outputs
+  core.setOutput("path", toolPath);
+  core.setOutput("version", targetVersion);
+
   // add the bin folder to the PATH
   core.addPath(path.join(toolPath, "bin"));
 }


### PR DESCRIPTION
# Changes

Declare outputs `path` and `version`
That way it follows the standard way used also by official gh-actions such as setup-java:
https://github.com/actions/setup-java/blob/main/action.yml#L71

# How was it tested ?
I tested it here: 
https://github.com/sebastienvermeille/another-protobuf-maven-plugin/blob/feature/rework-it-tests/.github/workflows/build.yml#L30

And the execution is here:
https://github.com/sebastienvermeille/another-protobuf-maven-plugin/actions/runs/6112694628/job/16590954927#step:7:1


Please let me know if something more is required from my side :+1:  happy to contribute :)
