### PR TITLE
Fix outputs path (append /bin)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -86,7 +86,7 @@ function getProtoc(version, includePreReleases, repoToken) {
             process.stdout.write("Protoc cached under " + toolPath + os.EOL);
         }
         // expose outputs
-        core.setOutput("path", toolPath);
+        core.setOutput("path", toolPath + path.sep + "bin");
         core.setOutput("version", targetVersion);
         // add the bin folder to the PATH
         core.addPath(path.join(toolPath, "bin"));

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -64,7 +64,7 @@ export async function getProtoc(
   }
 
   // expose outputs
-  core.setOutput("path", toolPath);
+  core.setOutput("path", toolPath + path.sep + "bin");
   core.setOutput("version", targetVersion);
 
   // add the bin folder to the PATH


### PR DESCRIPTION
# Fix outputs path (append /bin)

## Changes
* Append `/bin` to the output.path
  That way it provides a path to a dir which contains protoc executable as expected
  
The current path value provided by arduino/setup-protoc action requires me to do that workaround:
  https://github.com/sebastienvermeille/another-protobuf-maven-plugin/blob/master/.github/workflows/build.yml#L55
  

I believe it makes sense to have the `/bin` included so that we benefit directly access to the binaries of protoc.

> Note: please before merging this PR could you please add the label `HACKTOBERFEST-ACCEPTED` to this PR ? That would be greatly appreciated :) Thank's a lot
  