### PR TITLE
Install referenced schema in "npm:validate" task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,6 +147,10 @@ tasks:
       AVA_SCHEMA_URL: https://json.schemastore.org/ava.json
       AVA_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="ava-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/base.json
+      BASE_SCHEMA_URL: https://json.schemastore.org/base.json
+      BASE_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="base-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/eslintrc.json
       ESLINTRC_SCHEMA_URL: https://json.schemastore.org/eslintrc.json
       ESLINTRC_SCHEMA_PATH:
@@ -184,6 +188,7 @@ tasks:
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.BASE_SCHEMA_PATH}}" {{.BASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.ESLINTRC_SCHEMA_PATH}}" {{.ESLINTRC_SCHEMA_URL}}
       - wget --quiet --output-document="{{.JSCPD_SCHEMA_PATH}}" {{.JSCPD_SCHEMA_URL}}
       - wget --quiet --output-document="{{.NPM_BADGES_SCHEMA_PATH}}" {{.NPM_BADGES_SCHEMA_URL}}
@@ -197,6 +202,7 @@ tasks:
           --all-errors \
           -s "{{.SCHEMA_PATH}}" \
           -r "{{.AVA_SCHEMA_PATH}}" \
+          -r "{{.BASE_SCHEMA_PATH}}" \
           -r "{{.ESLINTRC_SCHEMA_PATH}}" \
           -r "{{.JSCPD_SCHEMA_PATH}}" \
           -r "{{.NPM_BADGES_SCHEMA_PATH}}" \


### PR DESCRIPTION
The `npm:validate` task validates the repository's `package.json` npm manifest file against its JSON schema to catch any problems with its data format.

In order to avoid duplication of content, JSON schemas may reference other schemas via the [`$ref` keyword](https://json-schema.org/learn/getting-started-step-by-step#external). The `package.json` schema was recently updated to share resources with the "base" configuration schema, which caused the validation to start failing:

https://github.com/arduino/setup-protoc/actions/runs/7728930562/job/21070931021#step:5:88

```text
schema /tmp/package-json-schema-norSGPxlCR.json is invalid
error: can't resolve reference https://json.schemastore.org/base.json#/definitions/license from id https://json.schemastore.org/package.json#
task: Failed to run task "npm:validate": exit status 1
```

The solution is to configure the task to download that schema as well and also to provide its path to the avj-cli validator via a `-r` flag.

---

This is a sync from the upstream "template" asset: https://github.com/arduino/tooling-project-assets/commit/c4393b06b13ea4fe3e9203f92bd669faacd01010