### PR TITLE
Updated default protoc version from 23.x to 26.x

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,8 @@ description: 'Download protoc compiler and add it to the PATH'
 author: 'Arduino'
 inputs:
   version:
-    description: 'Version to use. Example: 23.2'
-    default: '23.x'
+    description: 'Version to use. Example: 26.2'
+    default: '26.x'
   include-pre-releases:
     description: 'Include github pre-releases in latest version calculation'
     default: 'false'


### PR DESCRIPTION
Despite the readme saying that if you omit the version you will get the latest version, it actually installs version 23.x.
This one is outdated, and so I updated the default value to 26.x.

I'd prefer to see it not so hardcoded, but I figured this was a good short-term solution for the time being.