### PR TITLE
Configure actions/upload-artifact action to upload required hidden files

### DIFF
--- a/.github/workflows/check-npm-dependencies-task.yml
+++ b/.github/workflows/check-npm-dependencies-task.yml
@@ -105,6 +105,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
+          include-hidden-files: true
           name: dep-licenses-cache
           path: .licenses/
 


### PR DESCRIPTION
A breaking change was made in the 3.2.1 release of the [**actions/upload-artifact**](https://github.com/actions/upload-artifact) action (https://github.com/actions/upload-artifact/issues/602), without doing a major version bump as would be done in a responsibly maintained project. The action now defaults to not uploading "hidden" files.

This project's "**Check npm Dependencies**" workflow uses the [**Licensed**](https://github.com/github/licensed) tool to check for incompatible dependency licenses. The dependencies license metadata cache used by **Licensed** is stored in a folder named `.licensed`.

In order to facilitate updates, the workflow uploads the generated dependencies license metadata cache as a [workflow artifact](https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow#about-workflow-artifacts) when the current cache is found to be outdated.

The `.` at the start of the `.licensed` folder name causes it to now not be uploaded to the workflow artifact. In order to catch such problems, the workflow configures the **actions/upload-artifact** action to fail if no files were uploaded. So in addition to not uploading the artifact, the change in the "actions/upload-artifact" action's behavior also resulted in the workflow runs failing. For example:

https://github.com/arduino/setup-task/actions/runs/10682280265/job/29607763024?pr=1043#step:8:8

```text
Error: No files were found with the provided path: .licenses/. No artifacts will be uploaded.
```

The problem is fixed by disabling the **actions/upload-artifact** action's new behavior via [the `include-hidden-files` input](https://github.com/actions/upload-artifact#uploading-hidden-files).

After this change, the workflow can once more upload the dependencies license metadata cache to a workflow artifact as needed. For example:

https://github.com/arduino/setup-task/actions/runs/10688155948/job/29627399765?pr=1043#step:8:22

---

This is a sync from the upstream "template" in the assets repo: https://github.com/arduino/tooling-project-assets/pull/513
