### PR TITLE
Bump upload-artifact and actions/download-artifact from 3 to 4

### DIFF
--- a/.github/workflows/check-npm-dependencies-task.yml
+++ b/.github/workflows/check-npm-dependencies-task.yml
@@ -102,7 +102,7 @@ jobs:
       # Some might find it convenient to have CI generate the cache rather than setting up for it locally
       - name: Upload cache to workflow artifact
         if: failure() && steps.diff.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           include-hidden-files: true

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -80,7 +80,7 @@ jobs:
           file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
 
       - name: Pass configuration files to next job via workflow artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: |
             *.yaml
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download configuration files artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIGURATIONS_ARTIFACT }}
           path: ${{ env.CONFIGURATIONS_FOLDER }}


### PR DESCRIPTION
Artifact actions v3 is set to be deprecated by December 5, 2024 (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). I am updating actions/upload-artifact and actions/download-artifact to version 3.