### PR TITLE
Upgrade to Node 24

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -3,7 +3,7 @@ name: Check Markdown
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
+  NODE_VERSION: 24.x
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-npm-dependencies-task.yml
+++ b/.github/workflows/check-npm-dependencies-task.yml
@@ -3,7 +3,7 @@ name: Check npm Dependencies
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
+  NODE_VERSION: 24.x
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
@@ -102,7 +102,7 @@ jobs:
       # Some might find it convenient to have CI generate the cache rather than setting up for it locally
       - name: Upload cache to workflow artifact
         if: failure() && steps.diff.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           if-no-files-found: error
           include-hidden-files: true

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -3,7 +3,7 @@ name: Check npm
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
+  NODE_VERSION: 24.x
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-packaging-ncc-typescript-task.yml
+++ b/.github/workflows/check-packaging-ncc-typescript-task.yml
@@ -2,7 +2,7 @@ name: Check Packaging
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
+  NODE_VERSION: 24.x
 
 on:
   push:

--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -3,7 +3,7 @@ name: Check Taskfiles
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
+  NODE_VERSION: 24.x
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-tsconfig-task.yml
+++ b/.github/workflows/check-tsconfig-task.yml
@@ -2,7 +2,7 @@ name: Check TypeScript Configuration
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
+  NODE_VERSION: 24.x
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-typescript-task.yml
+++ b/.github/workflows/check-typescript-task.yml
@@ -3,7 +3,7 @@ name: Check TypeScript
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
+  NODE_VERSION: 24.x
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -3,7 +3,7 @@ name: Sync Labels
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
+  NODE_VERSION: 24.x
   CONFIGURATIONS_FOLDER: .github/label-configuration-files
   CONFIGURATIONS_ARTIFACT: label-configuration-files
 
@@ -80,13 +80,13 @@ jobs:
           file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
 
       - name: Pass configuration files to next job via workflow artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           path: |
             *.yaml
             *.yml
           if-no-files-found: error
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}-${{ matrix.filename }}
 
   sync:
     needs: download
@@ -118,15 +118,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download configuration files artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v6
         with:
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          pattern: ${{ env.CONFIGURATIONS_ARTIFACT }}-*
           path: ${{ env.CONFIGURATIONS_FOLDER }}
+          merge-multiple: true
 
       - name: Remove unneeded artifact
-        uses: geekyeggo/delete-artifact@v1
+        uses: geekyeggo/delete-artifact@v6
         with:
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}-*
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - name: npm install
         run: npm install


### PR DESCRIPTION
Node 20 actions are deprecated and GHA will
refuse to run them in a few months.

This change:
- upgrades the action to Node 24
- upgrades actions it uses to versions on Node 24
- modifies how upload-artifact is used, as required
  by a breaking change to that action.